### PR TITLE
"fix" server tests/get_submission/get_runs/timestamp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,24 @@
 # Game and Visualization Packages
 tqdm~=4.67.1
 pygame~=2.6.1
-numpy~=2.2.4
-opencv-python~=4.11.0.86
+numpy~=2.2.6
+opencv-python~=4.12.0.88
 
 # Testing Packages
-pytest~=8.3.4
+pytest~=9.0.2
 
 # Documentation Packages
-Sphinx~=8.1.3
-Myst-Parser~=4.0.0
+Sphinx~=8.2.3
+Myst-Parser~=4.0.1
+furo~=2025.12.19
+sphinx-autobuild~=2025.8.25
 
 # Server Packages
-psycopg2~=2.9.10
-SQLAlchemy~=2.0.2
-pydantic~=2.11.3
-fastapi[all]~=0.115.12
-schedule~=1.2.1
-requests~=2.32.3
-urllib3~=2.3.0
-pandas~=2.2.3
+psycopg2-binary~=2.9.11
+SQLAlchemy~=2.0.45
+pydantic~=2.12.5
+fastapi[all]~=0.127.1
+schedule~=1.2.2
+requests~=2.32.5
+urllib3~=2.6.2
+pandas~=2.3.3

--- a/server/main.py
+++ b/server/main.py
@@ -75,9 +75,12 @@ def run_with_return_to_client(func: Callable) -> Callable:
         """
         try:
             return func(*args, **kwargs)
+        # keep the status code if e was originally an HTTPException
+        except HTTPException as e:
+            raise e
+        # otherwise default to 500 since the error WAS serverside
         except Exception as e:
-            raise HTTPException(status_code=400, detail=str(e))
-
+            raise HTTPException(500, str(e))
     return wrapper
 
 
@@ -150,8 +153,8 @@ def get_submission(submission_id: int, team_uuid: str, db: Session = Depends(get
     submission_list: list[Submission] | None = crud_submission.read_all_W_filter(
         db, submission_id=submission_id, team_uuid=team_uuid)
 
-    if submission_list is None:
-        raise HTTPException(status_code=404, detail="Submission not found!")
+    if submission_list is None or len(submission_list) == 0:
+        raise HTTPException(404, "Submission not found!")
 
     return submission_list[0]  # returns a single SubmissionSchema to give the submission data to the user
 
@@ -176,8 +179,8 @@ def get_runs(tournament_id: int, team_uuid: str | None = None, db: Session = Dep
                                                              submission_run.submission is not None else None for
                                                              submission_run in run.submission_run_infos]]
 
-    if run_list is None:
-        raise HTTPException(status_code=404, detail="Run not found D:")
+    if run_list is None or len(run_list) == 0:
+        raise HTTPException(404, "Run not found D:")
 
     return run_list
 
@@ -244,7 +247,7 @@ def get_tournaments(db: Session = Depends(get_db)):
     temp: list[Tournament] = crud_tournament.read_all(db)
 
     if len(temp) == 0:
-        raise Exception('No tournaments found.')
+        raise HTTPException(404, 'No tournaments found.')
 
     return temp
 
@@ -262,7 +265,7 @@ def get_tournament(tournament_id: int, db: Session = Depends(get_db)):
     temp: Tournament = crud_tournament.read(db, tournament_id, eager=True)
 
     if temp is None:
-        raise Exception('No tournaments found.')
+        raise HTTPException(404, 'No tournaments found.')
 
     return temp
 
@@ -278,7 +281,7 @@ def get_latest_tournament(db: Session = Depends(get_db)):
     temp: Tournament = crud_tournament.get_latest_tournament(db)
 
     if temp is None:
-        raise Exception('No tournaments found.')
+        raise HTTPException(404, 'No tournaments found.')
 
     return temp
 

--- a/server/models/timestamp.py
+++ b/server/models/timestamp.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Optional
 import sqlalchemy as sa
 
 
@@ -8,15 +9,21 @@ class TimeStamp(sa.types.TypeDecorator):
     """
     impl = sa.types.DateTime
 
-# if datetime is none, returns datetime. if timezone is none, returns local timezone.
-    def process_bind_param(self, value: datetime, dialect):
+    def process_bind_param(self, value: Optional[datetime], dialect: sa.Dialect):
+        """
+        ensures `value` is converted to UTC before stored in the database
+        """
         if value is None:
-            return datetime.utcnow()
+            return datetime.now(tz=timezone.utc)
+        if not value.tzinfo is None:
+            return value.astimezone(timezone.utc)
 
         return value
 
-# changes timezone to utc timezone
-    def process_result_value(self, value: datetime, dialect):
+    def process_result_value(self, value: Optional[datetime], dialect: sa.Dialect):
+        """
+        ensures `value`'s timezone' is set to UTC when retrieved from the database
+        """ 
         if value is None:
             return value
         if value.tzinfo is None:

--- a/server/unit_tests/conftest.py
+++ b/server/unit_tests/conftest.py
@@ -1,0 +1,239 @@
+import pytest
+
+from datetime import datetime, timezone 
+from fastapi.testclient import TestClient
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import Session
+
+from server.main import app, get_db
+from server.models.base import Base
+from server.models.submission import Submission
+from server.models.submission_run_info import SubmissionRunInfo
+from server.models.team import Team
+from server.models.run import Run
+from server.models.team_type import TeamType
+from server.models.tournament import Tournament
+from server.models.university import University
+
+
+"""
+https://docs.pytest.org/en/stable/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files
+this file is used by pytest to share the fixtures below with other files that contain tests in this folder
+"""
+
+
+EXAMPLE_DATETIME = datetime.fromisoformat('2000-10-31T01:30:00-05:00')
+EXAMPLE_DATETIME_UTC = EXAMPLE_DATETIME.astimezone(timezone.utc)
+
+# datetimes in fastapi responses are represented as strings in ISO 8601 format https://fastapi.tiangolo.com/tutorial/extra-data-types/#other-data-types
+# our datetimes will always be in UTC
+# -> so their UTC offset is 0
+# -> which is replaced with a Z in ISO 8601 https://en.wikipedia.org/wiki/ISO_8601#:~:text=If%20the%20time%20is%20in%20UTC
+EXPECTED_DATETIME = EXAMPLE_DATETIME_UTC.isoformat().replace('+00:00', 'Z')
+EXPECTED_TEAM = {
+    "uni_id": 1,
+    "team_type_id": 1,
+    "team_name": "Noobss"
+}
+EXPECTED_RUN = {
+    "run_id": 1,
+    "tournament_id": 1,
+    "run_time": EXPECTED_DATETIME,
+    "seed": 1,
+    "results": 'test'
+}
+EXPECTED_TOURNAMENT = {
+    "tournament_id": 1,
+    "start_run": EXPECTED_DATETIME,
+    "launcher_version": "12",
+    "runs_per_client": 1,
+    "is_finished": True
+}
+EXPECTED_SUBMISSION_RUN_INFO = {
+    "submission_run_info_id": 1,
+    "run_id": 1,
+    "submission_id": 1,
+    "error_txt": "error",
+    "player_num": 1,
+    "points_awarded": 100,
+}
+EXPECTED_SUBMISSION = {
+    "submission_id": 1,
+    "submission_time": EXPECTED_DATETIME,
+    "file_txt": "test",
+}
+
+
+EXPECTED_SUBMISSION_RESPONSE = {
+    **EXPECTED_SUBMISSION,
+    "submission_run_infos": [
+        {
+            **EXPECTED_SUBMISSION_RUN_INFO,
+            "run": EXPECTED_RUN,
+        }
+    ],
+    "team": EXPECTED_TEAM,
+} 
+EXPECTED_RUN_RESPONSE = {
+    **EXPECTED_RUN,
+    "tournament": EXPECTED_TOURNAMENT,
+    "submission_run_infos": [
+        {
+            **EXPECTED_SUBMISSION_RUN_INFO,
+            "submission": {
+                **EXPECTED_SUBMISSION,
+                "team": EXPECTED_TEAM,
+            }
+        }
+    ],
+    "turns": []
+}
+
+@pytest.fixture(name='session')
+def session_fixture():
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={
+            'check_same_thread': False,
+        },
+        poolclass=StaticPool
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+        session.rollback()
+
+@pytest.fixture(name='client')
+def client_fixture(session: Session):
+    def get_db_override():
+        return session
+
+    # https://sqlmodel.tiangolo.com/tutorial/fastapi/tests/#override-a-dependency
+    app.dependency_overrides[get_db] = get_db_override
+
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+@pytest.fixture(autouse=True)
+def universities(session: Session):
+    university_names = [
+        'NDSU',
+        'MSUM',
+        'UND',
+        'Concordia',
+        'U of M',
+    ]
+    for i, name in enumerate(university_names):
+        # NOTE: the value of uni_id is not actually used since it's an auto-incremented field
+        session.add(University(
+            uni_id=i+1,
+            uni_name=name,
+        ))
+
+@pytest.fixture(autouse=True)
+def team_types(session: Session):
+    team_type_data = [
+        ('Undergrad', True),
+        ('Graduate', False), 
+        ('Alumni', False),
+    ]
+    for i, data in enumerate(team_type_data):
+        # NOTE: the value of team_type_id is not actually used since it's an auto-incremented field
+        session.add(TeamType(
+            team_type_id=i+1,
+            team_type_name=data[0],
+            eligible=data[1],
+        ))
+
+@pytest.fixture
+def example_team(session: Session):
+    session.add(Team(
+        uni_id=1,
+        team_type_id=1,
+        team_name="Noobss",
+        team_uuid="1",
+    ))
+
+@pytest.fixture
+def example_submission(session: Session, example_team):
+    session.add(Submission(
+        submission_id=1,
+        submission_time=EXAMPLE_DATETIME,
+        file_txt='test'.encode(),
+        team_uuid='1',
+    ))
+
+@pytest.fixture
+def another_submission(session: Session, example_submission):
+    session.add(Submission(
+        submission_id=2,
+        submission_time=EXAMPLE_DATETIME,
+        file_txt='test'.encode(),
+        team_uuid='1',
+    ))
+
+@pytest.fixture
+def example_tournament(session: Session):
+    session.add(Tournament(
+        start_run=EXAMPLE_DATETIME,
+        launcher_version='12',
+        runs_per_client=1,
+        is_finished=True,
+    ))
+
+@pytest.fixture
+def another_tournament(session: Session, example_tournament):
+    session.add(Tournament(
+        tournament_id=2,
+        start_run=EXAMPLE_DATETIME,
+        launcher_version='10',
+        runs_per_client=2,
+        is_finished=False,
+    ))
+
+@pytest.fixture
+def example_run(session: Session, example_tournament):
+    session.add(Run(
+        run_id=1,
+        tournament_id=1,
+        run_time=EXAMPLE_DATETIME,
+        seed=1,
+        results='test'.encode()
+    ))
+
+@pytest.fixture
+def more_runs(session: Session, example_run, another_tournament):
+    session.add_all([
+        Run(
+            run_id=2,
+            tournament_id=1,
+            run_time=EXAMPLE_DATETIME,
+            seed=2,
+            results='test'.encode()
+        ),
+        Run(
+            run_id=3,
+            tournament_id=2,
+            run_time=EXAMPLE_DATETIME,
+            seed=1,
+            results='test'.encode()
+        ),
+        Run(
+            run_id=4,
+            tournament_id=2,
+            run_time=EXAMPLE_DATETIME,
+            seed=2,
+            results='test'.encode()
+        )
+    ])
+
+@pytest.fixture
+def example_submission_run_info(session: Session, example_run, example_submission):
+    session.add(SubmissionRunInfo(
+        run_id=1,
+        submission_id=1,
+        error_txt='error'.encode(),
+        player_num=1,
+        points_awarded=100,
+    ))

--- a/server/unit_tests/test_main.py
+++ b/server/unit_tests/test_main.py
@@ -1,46 +1,19 @@
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from server.main import app
 
-client = TestClient(app=app)
+from server.unit_tests.conftest import EXPECTED_SUBMISSION_RESPONSE
 
 
-def test_read_root():
+
+def test_read_root(client: TestClient):
     response = client.get('/')
     assert response.json() == {'message': 'Hello World'}
 
+def test_read_get_submission(client: TestClient, example_team, example_submission, example_submission_run_info):
+    response = client.get('/submission?submission_id=1&team_uuid=1')
+    assert response.status_code == 200, response.json()['detail']
+    assert response.json() == EXPECTED_SUBMISSION_RESPONSE
 
-def test_read_get_submission():
-    response = client.get('/get_submission/1/1/')
-    assert response.json() == {"submission_id": 1,
-         "submission_time": "2000-10-31T01:30:00-05:00",
-         "file_txt": "test",
-         "team": {"uni_id": 1,
-                  "team_type_id": 1,
-                  "team_name": "Noobs"},
-         "submission_run_infos": [{"submission_run_info_id": 1,
-                                   "run_id": 1,
-                                   "submission_id": 1,
-                                   "error_txt": "error",
-                                   "run": {"run_id": 1,
-                                           "group_run_id": 1,
-                                           "run_time": "2000-10-31T01:30:00-05:00",
-                                           "seed": 1}}]}
-
-
-def test_read_get_submissions():
-    response = client.get('/get_submissions/1')
-    assert response.json() == [{"submission_id": 1,
-        "submission_time": "2000-10-31T01:30:00-05:00",
-        "file_txt": "test",
-        "team": {"uni_id": 1,
-                "team_type_id": 1,
-                "team_name": "Noobs"},
-        "submission_run_infos": [{"submission_run_info_id": 1,
-                                    "run_id": 1,
-                                    "submission_id": 1,
-                                    "error_txt": "error",
-                                    "run": {"run_id": 1,
-                                            "group_run_id": 1,
-                                            "run_time": "2000-10-31T01:30:00-05:00",
-                                            "seed": 1}}]},]
+def test_read_get_submissions(client: TestClient, example_team, example_submission, example_submission_run_info):
+    response = client.get('/submissions?team_uuid=1')
+    assert response.status_code == 200, response.json()['detail']
+    assert response.json() == [EXPECTED_SUBMISSION_RESPONSE]

--- a/server/unit_tests/test_run.py
+++ b/server/unit_tests/test_run.py
@@ -1,88 +1,49 @@
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from server.main import app
-import pytest
 
-client = TestClient(app=app)
+from server.unit_tests.conftest import EXPECTED_DATETIME, EXPECTED_RUN_RESPONSE
+
 
 
 # Test Run methods in main.py
 
 # Test get_run method
-def test_get_runs_param() -> None:
+def test_get_runs_param(client: TestClient, example_run, example_submission_run_info, example_tournament) -> None:
     """
     Tests getting the runs by using the tournament id and team uuid in the URL.
     :return: None
     """
     response = client.get('/runs?tournament_id=1&team_uuid=1')
     assert response.status_code == 200
-    print(response.json())
-    assert response.json() == [
-        {
-            "run_id": 1,
-            "tournament_id": 1,
-            "run_time": "2000-10-31T06:30:00Z",
-            "seed": 1,
-            "results": "test",
-            "tournament": {
-                "tournament_id": 1,
-                "start_run": "2000-10-31T06:30:00Z",
-                "launcher_version": "12",
-                "runs_per_client": 1,
-                "is_finished": True
-            },
-            "submission_run_infos": [
-                {
-                    "submission_run_info_id": 1,
-                    "run_id": 1,
-                    "submission_id": 1,
-                    "error_txt": "error",
-                    "player_num": 1,
-                    "points_awarded": 100,
-                    "submission": {
-                        "submission_id": 1,
-                        "submission_time": "2000-10-31T06:30:00Z",
-                        "file_txt": "test",
-                        "team": {
-                            "uni_id": 1,
-                            "team_type_id": 1,
-                            "team_name": "Noobs"
-                        }
-                    }
-                }
-            ],
-            "turns": []
-        }
-    ]
+    assert response.json() == [EXPECTED_RUN_RESPONSE]
 
 
 # Test run method
-def test_get_runs() -> None:
+def test_get_runs(client: TestClient, more_runs) -> None:
     """
     Tests getting all runs in the database via the URL.
     :return: None
     """
     response = client.get('/runs/')
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.json()['detail']
     assert response.json() == [{"run_id": 1,
                                 "tournament_id": 1,
-                                "run_time": "2000-10-31T06:30:00Z",
+                                "run_time": EXPECTED_DATETIME,
                                 "seed": 1,
                                 "results": "test"},
                                {"run_id": 2,
                                 "tournament_id": 1,
-                                "run_time": "2000-10-31T06:30:00Z",
+                                "run_time": EXPECTED_DATETIME,
                                 "seed": 2,
                                 "results": "test"},
                                {"run_id": 3,
                                 "tournament_id": 2,
-                                "run_time": "2000-10-31T06:30:00Z",
+                                "run_time": EXPECTED_DATETIME,
                                 "seed": 1,
                                 "results": "test"},
                                {"run_id": 4,
                                 "tournament_id": 2,
-                                "run_time": "2000-10-31T06:30:00Z",
+                                "run_time": EXPECTED_DATETIME,
                                 "seed": 2,
                                 "results": "test"}
                                ]

--- a/server/unit_tests/test_submission.py
+++ b/server/unit_tests/test_submission.py
@@ -1,105 +1,49 @@
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from server.main import app
-import pytest
 
-client = TestClient(app=app)
+from server.unit_tests.conftest import EXPECTED_DATETIME, EXPECTED_SUBMISSION, EXPECTED_SUBMISSION_RESPONSE, EXPECTED_TEAM
 
 
-# Test Submission methods in main.py
-
-# Test post method
-
-
-def test_post_submission() -> None:
+def test_post_submission(client: TestClient, example_team) -> None:
     """
     Tests posting a submission via the URL.
     :return: None
     """
     response = client.post('/submission/',
                            json={"team_uuid": '1',
-                                 "submission_id": 2,
+                                 "submission_id": 1,
                                  "submission_time": "2000-10-31T01:30:00-05:00",
                                  "file_txt": 'test'}
                            )
-    assert response.status_code == 200
-    assert response.json() == {"submission_id": 2,
-                               "submission_time": "2000-10-31T06:30:00Z",
-                               "file_txt": "test"}
+    assert response.status_code == 200, response.json()['detail']
+    assert response.json() == EXPECTED_SUBMISSION
 
 
 # Test get methods
 
-def test_get_submission() -> None:
+def test_get_submission(client: TestClient, example_submission, example_submission_run_info) -> None:
     """
     Tests getting a submission via the submission id and team uuid in the URL.
     :return: None
     """
     response = client.get('/submission?submission_id=1&team_uuid=1')
-    assert response.status_code == 200
-    assert response.json() == {"submission_id": 1,
-                               "submission_time": "2000-10-31T06:30:00Z",
-                               "file_txt": "test",
-                               "team": {"uni_id": 1,
-                                        "team_type_id": 1,
-                                        "team_name": "Noobs"},
-                               "submission_run_infos": [{"submission_run_info_id": 1,
-                                                         "run_id": 1,
-                                                         "submission_id": 1,
-                                                         "error_txt": "error",
-                                                         "player_num": 1,
-                                                         "points_awarded": 100,
-                                                         "run": {"run_id": 1,
-                                                                 "tournament_id": 1,
-                                                                 "run_time": "2000-10-31T06:30:00Z",
-                                                                 "seed": 1,
-                                                                 "results": "test"}}]}
+    assert response.status_code == 200, response.json()['detail']
+    assert response.json() == EXPECTED_SUBMISSION_RESPONSE
 
 
-def test_get_submissions() -> None:
+def test_get_submissions(client: TestClient, example_submission, example_submission_run_info, another_submission) -> None:
     """
     Tests getting all submissions given a team uuid in the URL.
     :return: None
     """
     response = client.get('/submissions?team_uuid=1')
-    assert response.status_code == 200
+    assert response.status_code == 200, response.json()['detail']
     assert response.json() == [
-        {
-            "submission_id": 1,
-            "submission_time": "2000-10-31T06:30:00Z",
-            "file_txt": "test",
-            "team": {
-                "uni_id": 1,
-                "team_type_id": 1,
-                "team_name": "Noobs"
-            },
-            "submission_run_infos": [
-                {
-                    "submission_run_info_id": 1,
-                    "run_id": 1,
-                    "submission_id": 1,
-                    "error_txt": "error",
-                    "player_num": 1,
-                    "points_awarded": 100,
-                    "run": {
-                        "run_id": 1,
-                        "tournament_id": 1,
-                        "run_time": "2000-10-31T06:30:00Z",
-                        "seed": 1,
-                        "results": "test"
-                    }
-                }
-            ]
-        },
+        EXPECTED_SUBMISSION_RESPONSE,
         {
             "submission_id": 2,
-            "submission_time": "2000-10-31T06:30:00Z",
+            "submission_time": EXPECTED_DATETIME,
             "file_txt": "test",
-            "team": {
-                "uni_id": 1,
-                "team_type_id": 1,
-                "team_name": "Noobs"
-            },
+            "team": EXPECTED_TEAM,
             "submission_run_infos": []
         }
     ]
@@ -107,10 +51,11 @@ def test_get_submissions() -> None:
 
 # Test read nonexistent submission/s
 
-def test_get_nonexistent_submission() -> None:
+def test_get_nonexistent_submission(client: TestClient) -> None:
     """
     Tests that a non-existent submission cannot be retrieved; raises an error.
     :return: None
     """
-    with pytest.raises(IndexError):
-        client.get('/submission?submission_id=2&team_uuid=2')
+    response = client.get('/submission?submission_id=2&team_uuid=2')
+    assert response.status_code == 404, response.json()['detail']
+    assert 'Submission not found' in response.json()['detail']

--- a/server/unit_tests/test_team.py
+++ b/server/unit_tests/test_team.py
@@ -1,25 +1,52 @@
-from fastapi import FastAPI
+import pytest
 from fastapi.testclient import TestClient
-from server.main import app
+from sqlalchemy.orm import Session
 
-client = TestClient(app=app)
-
-# Test Team methods in main.py
-
-# Test post method
+from server.crud import crud_team
+from server.schemas.team.team_base import TeamBase
 
 
-def test_post_team() -> None:
+@pytest.fixture
+def request_json():
+    return {
+        "uni_id": 1,
+        "team_type_id": 1,
+        "team_name": "Noobss",
+    }
+
+def test_post_team(client: TestClient, request_json: dict) -> None:
     """
     Tests that creating a team works as expected.
     :return: None
     """
-    response = client.post('/team/',
-                           json={"uni_id": 1,
-                                 "team_type_id": 1,
-                                 "team_name": "Noobss"}
-                           )
-    assert response.status_code == 200
-    assert response.json()['uni_id'] == 1
-    assert response.json()['team_type_id'] == 1
-    assert response.json()['team_name'] == "Noobss"
+    response = client.post('/team/', json=request_json)
+    assert response.status_code == 200, response.json()['detail']
+    assert response.json()['uni_id'] == request_json['uni_id']
+    assert response.json()['team_type_id'] == request_json['team_type_id']
+    assert response.json()['team_name'] == request_json['team_name']
+
+def test_post_team_invalid_team_type(client: TestClient, request_json: dict) -> None:
+    request_json['team_type_id'] = -1
+
+    response = client.post('/team/', json=request_json)
+    assert response.status_code == 500, response.json()['detail']
+
+def test_post_team_invalid_university(client: TestClient, request_json: dict) -> None:
+    request_json['uni_id'] = -1
+
+    response = client.post('/team/', json=request_json)
+    assert response.status_code == 500, response.json()['detail']
+
+def test_post_team_empty_name(client: TestClient, request_json: dict) -> None:
+    request_json['team_name'] = ''
+
+    response = client.post('/team/', json=request_json)
+    assert response.status_code == 500, response.json()['detail']
+
+def test_post_team_duplicate_name(session: Session, client: TestClient, request_json: dict) -> None:
+    crud_team.create(TeamBase(**request_json), session)
+
+    response = client.post('/team/', json=request_json)
+    assert response.status_code == 500, response.json()['detail']
+    assert 'pre-existing team name' in response.json()['detail']
+

--- a/server/unit_tests/test_team_types.py
+++ b/server/unit_tests/test_team_types.py
@@ -1,9 +1,4 @@
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from server.main import app
-import pytest
-
-client = TestClient(app=app)
 
 
 # Test Team Types methods in main.py
@@ -11,17 +6,20 @@ client = TestClient(app=app)
 # Test get method
 
 
-def test_get_team_types() -> None:
+def test_get_team_types(client: TestClient) -> None:
     """
     Tests that the team types are returned correctly.
     :return: None
     """
     response = client.get('/team_types/')
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.json()['detail']
     assert response.json() == [{"team_type_id": 1,
                                 "team_type_name": "Undergrad",
                                 "eligible": True},
                                {"team_type_id": 2,
-                                "team_type_name": "Grad",
+                                "team_type_name": "Graduate",
+                                "eligible": False},
+                               {"team_type_id": 3,
+                                "team_type_name": "Alumni",
                                 "eligible": False}]

--- a/server/unit_tests/test_tournament.py
+++ b/server/unit_tests/test_tournament.py
@@ -1,95 +1,27 @@
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from server.main import app
-import pytest
 
-client = TestClient(app=app)
+from server.unit_tests.conftest import EXPECTED_TOURNAMENT
 
 
 # Test Submission methods in main.py
 
 # Test get method
 
-def test_get_tournaments() -> None:
+def test_get_tournaments(client: TestClient, example_tournament, another_tournament) -> None:
     """
     Tests getting the list of tournaments that are stored in teh database.
     :return: None
     """
     response = client.get('/tournaments/')
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.json()['detail']
     assert response.json() == [
-        {
-            "tournament_id": 1,
-            "start_run": "2000-10-31T06:30:00Z",
-            "launcher_version": "12",
-            "runs_per_client": 1,
-            "is_finished": True,
-            "runs": [
-                {
-                    "run_id": 1,
-                    "tournament_id": 1,
-                    "run_time": "2000-10-31T06:30:00Z",
-                    "seed": 1,
-                    "results": "test",
-                    "submission_run_infos": [
-                        {
-                            "submission_run_info_id": 1,
-                            "run_id": 1,
-                            "submission_id": 1,
-                            "error_txt": "error",
-                            "player_num": 1,
-                            "points_awarded": 100,
-                            "submission": {
-                                "submission_id": 1,
-                                "submission_time": "2000-10-31T06:30:00Z",
-                                "file_txt": "test",
-                                "team": {
-                                    "uni_id": 1,
-                                    "team_type_id": 1,
-                                    "team_name": "Noobs"
-                                }
-                            }
-                        }
-                    ],
-                    "turns": []
-                },
-                {
-                    "run_id": 2,
-                    "tournament_id": 1,
-                    "run_time": "2000-10-31T06:30:00Z",
-                    "seed": 2,
-                    "results": "test",
-                    "submission_run_infos": [],
-                    "turns": []
-                }
-            ]
-        },
+        EXPECTED_TOURNAMENT,
         {
             "tournament_id": 2,
             "start_run": "2000-10-31T06:30:00Z",
             "launcher_version": "10",
             "runs_per_client": 2,
             "is_finished": False,
-            "runs": [
-                {
-                    "run_id": 3,
-                    "tournament_id": 2,
-                    "run_time": "2000-10-31T06:30:00Z",
-                    "seed": 1,
-                    "results": "test",
-                    "submission_run_infos": [],
-                    "turns": []
-                },
-                {
-                    "run_id": 4,
-                    "tournament_id": 2,
-                    "run_time": "2000-10-31T06:30:00Z",
-                    "seed": 2,
-                    "results": "test",
-                    "submission_run_infos": [],
-                    "turns": []
-                }
-            ]
         }
     ]

--- a/server/unit_tests/test_university.py
+++ b/server/unit_tests/test_university.py
@@ -1,24 +1,25 @@
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from server.main import app
-import pytest
-
-client = TestClient(app=app)
 
 
 # Test University methods in main.py
 
 # Test get method
 
-def test_get_universities() -> None:
+def test_get_universities(client: TestClient) -> None:
     """
     Tests that getting the universities in from the database works.
     :return: None
     """
     response = client.get('/universities/')
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.json()['detail']
     assert response.json() == [{"uni_id": 1,
                                 "uni_name": "NDSU"},
                                {"uni_id": 2,
-                                "uni_name": "UND"}]
+                                "uni_name": "MSUM"},
+                               {"uni_id": 3,
+                                "uni_name": "UND"},
+                               {"uni_id": 4,
+                                "uni_name": "Concordia"},
+                               {"uni_id": 5,
+                                "uni_name": "U of M"}]


### PR DESCRIPTION
- create a mock database specifically for running unit tests instead of reusing `byte_server.db`
- use pytest fixtures to share a FastAPI `TestClient` that connects to the mock database
- fix some endpoints not emitting a 404 when they fetched an empty list
- fix timestamps not being stored in UTC <-- might be a lie
- update packages